### PR TITLE
[2주차] 김재현 - 월 덱, 풍선터트리기

### DIFF
--- a/재현/2주차/월/덱.java
+++ b/재현/2주차/월/덱.java
@@ -1,0 +1,94 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+class 덱 {
+    static int input;
+    static String cmd;
+    static Deque d;
+    static BufferedReader br;
+    static StringTokenizer st;
+    static StringBuilder sb;
+
+    public static void main(String[] args) throws Exception {
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        sb = new StringBuilder();
+        d = new Deque();
+
+        input = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < input; i++) {
+            st = new StringTokenizer(br.readLine());
+            cmd = st.nextToken();
+
+            switch (cmd) {
+                case "push_front":
+                    d.push_front(Integer.parseInt(st.nextToken())); break;
+                case "push_back":
+                    d.push_back(Integer.parseInt(st.nextToken())); break;
+                case "pop_front":
+                    sb.append(d.pop_front()).append("\n"); break;
+                case "pop_back":
+                    sb.append(d.pop_back()).append("\n"); break;
+                case "size":
+                    sb.append(d.size()).append("\n"); break;
+                case "empty":
+                    sb.append(d.empty() ? 1 : 0).append("\n"); break;
+                case "front":
+                    sb.append(d.front()).append("\n"); break;
+                case "back":
+                    sb.append(d.back()).append("\n"); break;
+
+            }
+        }
+
+        System.out.println(sb);
+        br.close();
+    }
+}
+
+
+class Deque {
+    static final int MAX_SIZE = 20001;
+    int[] list;
+    int front;
+    int rear;
+
+    Deque () {
+        list = new int[MAX_SIZE];
+        front = rear = MAX_SIZE / 2;
+    }
+
+    void push_front(int data) {
+        list[--front] = data;
+    }
+
+    void push_back(int data) {
+        list[rear++] = data;
+    }
+
+    int pop_front() {
+        return empty() ? -1 : list[front++];
+    }
+
+    int pop_back() {
+        return empty() ? -1 : list[--rear];
+    }
+
+    int size() {
+        return rear - front;
+    }
+
+    boolean empty() {
+        return front == rear;
+    }
+
+    int front() {
+        return empty() ? -1 : list[front];
+    }
+
+    int back() {
+        return empty() ? -1 : list[rear - 1];
+    }
+}

--- a/재현/2주차/월/풍선터트리기.java
+++ b/재현/2주차/월/풍선터트리기.java
@@ -1,0 +1,47 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+class 풍선터트리기 {
+    static int n;
+    static BufferedReader br;
+    static StringBuilder sb;
+    static StringTokenizer st;
+    static Deque<int[]> d;
+    public static void main(String[] args) throws Exception {
+
+        br = new BufferedReader(new InputStreamReader(System.in));
+        sb = new StringBuilder();
+        d = new ArrayDeque<>();
+
+        n = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            d.add(new int[]{i + 1, Integer.parseInt(st.nextToken())});
+        }
+
+        while (!d.isEmpty()) {
+            int[] cur = d.pollFirst();
+            sb.append(cur[0]).append(" ");
+
+            if(d.isEmpty()) break;
+
+            if (cur[1] > 0) {
+                for (int i = 0; i < cur[1] - 1; i++) {
+                    d.addLast(d.pollFirst());
+                }
+            } else {
+                for (int i = 0; i < -cur[1]; i++) {
+                    d.addFirst(d.pollLast());
+                }
+            }
+        }
+
+        System.out.println(sb);
+        br.close();
+
+    }
+}


### PR DESCRIPTION
###문제 풀이
1. 덱
 - 직접 Deque 클래스를 구현하여 덱의 모슨 연산을 배열 기반으로 처리하였습니다.
 - MAX_SIZE를 지정하고 front, rear 포인터를 가운데부터 시작하게 하여 양방향 삽입과 삭제 연산을 O(1) 시간에 구현했습니다.

2. 풍선터트리기
 - 덱의 양방향 이동을 활용하여 문제를 해결하였습니다.
 - 앞에서 poll 하고 뒤에만 add를 하기 때문에 LinkedList 보다는 ArrayDeque를 이용했습니다.
 - 풍선의 번호가 양수일 경우 pollFirst() 후 addLast()
 - 풍선의 번호가 음수일 경우 pollLast() 후 addFirst()를 반복하며 문제를 해결하였습니다.