### PR TITLE
[2주차] 한지은 - 수 문자열 집합, 세로읽기

### DIFF
--- a/지은/2주차/수/문자열_집합.java
+++ b/지은/2주차/수/문자열_집합.java
@@ -1,0 +1,35 @@
+import java.io.*;
+import java.util.*;
+
+public class 문자열_집합 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        // 첫 줄 입력: N은 집합 S의 문자열 수, M은 검사할 문자열 수
+        String[] input = br.readLine().split(" ");
+        int N = Integer.parseInt(input[0]);
+        int M = Integer.parseInt(input[1]);
+
+        // 집합 S 저장하는 HashSet
+        Set<String> set = new HashSet<>();
+
+        // 집합 S의 문자열 입력받아 저장
+        for (int i = 0; i < N; i++) {
+            set.add(br.readLine());
+        }
+
+        int count = 0; // 집합에 포함된 문자열 개수
+
+        // 검사할 문자열을 하나씩 받아서 집합에 포함되어 있으면 count 증가
+        for (int i = 0; i < M; i++) {
+            String str = br.readLine();
+            if (set.contains(str)) {
+                count++;
+            }
+        }
+
+        sb.append(count).append('\n');
+        System.out.print(sb);
+    }
+}

--- a/지은/2주차/수/세로읽기.java
+++ b/지은/2주차/수/세로읽기.java
@@ -1,0 +1,31 @@
+import java.io.*;
+
+public class 세로읽기 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        String[] lines = new String[5]; // 단어 5줄 저장
+        int maxLength = 0; // 가장 긴 문자열 길이 저장
+
+        for (int i = 0; i < 5; i++) {
+            lines[i] = br.readLine();
+            if (lines[i].length() > maxLength) {
+                maxLength = lines[i].length();
+            }
+        }
+
+        // 열 우선 순회 (세로 읽기)
+        for (int col = 0; col < maxLength; col++) {
+            for (int row = 0; row < 5; row++) {
+                // 해당 줄에 해당 열 문자가 존재할 때만 출력
+                if (col < lines[row].length()) {
+                    sb.append(lines[row].charAt(col));
+                }
+            }
+        }
+
+        // 결과 출력
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 문자열_집합
- 처음에는 ArrayList를 사용해서 풀이했습니다.
- 그런데 다른 사람들 풀이를 보니 대부분 HashSet을 사용하고 있었고, 성능 차이가 궁금해서 HashSet으로 변경해보았습니다.
- 직접 측정해보니 HashSet 사용 시  2800ms -> 384ms로 약 7배 이상 성능 차이가 났습니다.
- HashSet은 contains() 호출 시 평균 시간복잡도가 O(1)이기 때문에, '존재 여부 확인' 같은 상황에서 사용하면 아주 유리하다는 걸 이번에 알게 되었습니다.

---

## 세로읽기
- 5줄의 문자열을 세로로 읽어서 하나의 문자열로 이어붙이는 문제.
- 문자열 길이가 제각각이라서 단순하게 2중 for문으로 돌리면 인덱스 오류가 날 것 같았습니다.
- 그래서 먼저 각 문자열을 배열에 저장하고, 가장 긴 문자열의 길이를 기준으로 열을 순회하도록 했습니다.
- 세로로 읽는 방식은 col(열) → row(행) 순서로 반복하면서, 해당 인덱스에 문자가 존재할 때만 append하도록 조건을 넣었습니다.
