### PR TITLE
[5주차] 이유민 - 수 게임 맵 최단거리, 여행경로

### DIFF
--- a/유민/5주차/수/게임_맵_최단거리.java
+++ b/유민/5주차/수/게임_맵_최단거리.java
@@ -1,0 +1,40 @@
+import java.util.*;
+
+public class 게임_맵_최단거리 {
+    public int solution(int[][] maps) {
+        int n = maps.length;
+        int m = maps[0].length;
+
+        int[] dx = {-1, 1, 0, 0};
+        int[] dy = {0, 0, -1, 1};
+
+        int[][] distance = new int[n][m];
+        boolean[][] visited = new boolean[n][m];
+
+        Queue<int[]> q = new LinkedList<>();
+        q.add(new int[]{0, 0});
+        visited[0][0] = true;
+        distance[0][0] = 1;
+
+        while(!q.isEmpty()) {
+            int[] current = q.poll();
+            int x = current[0];
+            int y = current[1];
+
+            for (int i = 0; i < 4; i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+
+                if (nx >= 0 && ny >= 0 && nx < n && ny < m) {
+                    if (maps[nx][ny] == 1 && !visited[nx][ny]) {
+                        visited[nx][ny] = true;
+                        distance[nx][ny] = distance[x][y] + 1;
+                        q.add(new int[]{nx, ny});
+                    }
+                }
+            }
+        }
+
+        return distance[n-1][m-1] == 0 ? -1 : distance[n-1][m-1];
+    }
+}

--- a/유민/5주차/수/여행경로.java
+++ b/유민/5주차/수/여행경로.java
@@ -1,0 +1,30 @@
+import java.util.*;
+
+public class 여행경로 {
+    private List<String> list = new ArrayList<>();
+    private boolean[] used;
+
+    public String[] solution(String[][] tickets) {
+        used = new boolean[tickets.length];
+
+        dfs("ICN", "ICN", tickets, 0);
+
+        Collections.sort(list);
+        return list.get(0).split(" ");
+    }
+
+    public void dfs(String current, String path, String[][] tickets, int depth) {
+        if (depth == tickets.length) {
+            list.add(path);
+            return;
+        }
+
+        for(int i = 0; i < tickets.length; i++) {
+            if (!used[i] && tickets[i][0].equals(current)) {
+                used[i] = true;
+                dfs(tickets[i][1], path + " " + tickets[i][1], tickets, depth + 1);
+                used[i] = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 여행경로
dfs를 활용해 모든 티켓을 사용한 경로를 탐색하고 사전순으로 가장 빠른 경로를 선택하는 방식으로 풀이했습니다!
- 티켓 사용 여부는 boolean 배열로 추적했고,
- 경로는 문자열로 누적하여 완성된 경로만 리스트에 저장하면서
- 정렬 후 가장 앞선 경로를 정답으로 리턴했습니다.

## 게임 맵 최단거리
최단 거리를 구해야 해서 bfs로 풀이했습니다.
- 큐에 현재 위치를 저장하고
- 거리 배열과 visited 배열을 별도로 유지하면서
- 상하좌우를 탐색해 도착지에 가장 먼저 도달했을 때의 거리를 반환하고
도착하지 못할 경우 -1을 반환하도록 구현했습니다.