### PR TITLE
[5주차] 한지은 - 수 게임 맵 최단거리, 여행 경로

### DIFF
--- a/지은/5주차/수/게임 맵 최단거리.java
+++ b/지은/5주차/수/게임 맵 최단거리.java
@@ -1,0 +1,41 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int[][] maps) {
+        int n = maps.length;       // 세로 길이
+        int m = maps[0].length;    // 가로 길이
+
+        // 상하좌우 방향 이동
+        int[] dx = {0, 0, -1, 1};
+        int[] dy = {-1, 1, 0, 0};
+
+        boolean[][] visited = new boolean[n][m]; 
+        Queue<int[]> queue = new LinkedList<>(); 
+
+        queue.add(new int[]{0, 0}); // 시작 위치 추가
+        visited[0][0] = true;       // 시작 위치 방문 처리
+
+        while (!queue.isEmpty()) {
+            int[] current = queue.poll();
+            int x = current[0];
+            int y = current[1];
+
+            // 네 방향으로 이동
+            for (int i = 0; i < 4; i++) {
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+
+                // 범위 안이고, 갈 수 있는 길(1)이고, 아직 방문하지 않은 칸
+                if (nx >= 0 && ny >= 0 && nx < n && ny < m) {
+                    if (maps[nx][ny] == 1 && !visited[nx][ny]) {
+                        visited[nx][ny] = true;
+                        maps[nx][ny] = maps[x][y] + 1; // 지금까지의 거리 + 1
+                        queue.add(new int[]{nx, ny});
+                    }
+                }
+            }
+        }
+       // 도착점이 여전히 1이면 도달 불가
+        return maps[n - 1][m - 1] == 1 ? -1 : maps[n - 1][m - 1];
+    }
+}

--- a/지은/5주차/수/여행 경로.java
+++ b/지은/5주차/수/여행 경로.java
@@ -1,0 +1,46 @@
+import java.util.*;
+
+public class Solution {
+    boolean[] visited; // 티켓 사용 여부
+    List<String> answer = new ArrayList<>(); // 경로들을 문자열로 저장
+
+    public String[] solution(String[][] tickets) {
+        visited = new boolean[tickets.length]; // 티켓 수만큼 visited 초기화
+
+        // 티켓을 출발지 → 도착지 기준으로 사전순 정렬
+        Arrays.sort(tickets, (a, b) -> {
+            if (a[0].equals(b[0]))
+                return a[1].compareTo(b[1]);
+            return a[0].compareTo(b[0]);
+        });
+
+        // 경로를 저장할 리스트 항상 ICN 출발
+        List<String> route = new ArrayList<>();
+        route.add("ICN");
+
+        // DFS 탐색
+        DFS(0, "ICN", route, tickets);
+
+        // 사전순으로 가장 앞선 경로만 반환
+        return answer.get(0).split(" ");
+    }
+
+    void DFS(int idx, String start, List<String> route, String[][] tickets) {
+        // 모든 티켓을 사용한 경우 = 경로 완성
+        if (idx == tickets.length) {
+            answer.add(String.join(" ", route)); // 공백 구분하여 문자열로 저장
+            return;
+        }
+
+        // 현재 위치에서 출발 가능한 모든 티켓 탐색
+        for (int i = 0; i < tickets.length; i++) {
+            if (!visited[i] && tickets[i][0].equals(start)) {
+                visited[i] = true; // 티켓 사용
+                route.add(tickets[i][1]); // 도착지 추가
+                DFS(idx + 1, tickets[i][1], route, tickets); // 다음 공항으로 이동
+                visited[i] = false;
+                route.remove(route.size() - 1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 게임 맵 최단거리
- 최단 경로 탐색 문제로,BFS 사용
- 큐 사용하여 현재 위치에서 상하좌우 확장하여 탐색
- 방문한 좌표는 visited[][] 배열로 관리하고, 이동 가능한 경로는 maps[x][y] == 1 조건으로 판단
- 탐색이 끝난 뒤 도착지 좌표 (n-1, m-1)의 값이 여전히 1이라면 도달하지 못한 것으로 판단하고 -1을 반환
- 도달한 경우 해당 좌표에 누적된 값을 최단 거리로 반환
---
## 여행 경로
- 티켓을 사전순으로 정렬한 뒤 DFS로 모든 경로 탐색
- 경로는 List<String>에 누적 후 저장
- 사전순으로 가장 빠른 경로가 탐색되어 첫 번째 결과를 반환
- 개선할 점: 현재는 모든 경로를 탐색하지만, 불필요한 재귀를 줄이도록 최적화하면 더 좋을 것 같다.
  - (예: 사전순 정렬이 되어 있다면, 첫 정답 이후 탐색을 종료하는 방식)
