### PR TITLE
[6주차] 김재현 - 월 모음 사전, 전력망을 둘로 나누기

### DIFF
--- a/재현/6주차/월/모음 사전.java
+++ b/재현/6주차/월/모음 사전.java
@@ -1,0 +1,25 @@
+import java.util.*;
+
+class Solution {
+    static List<String> list = new ArrayList<>();
+    static char[] vowels = {'A', 'E', 'I', 'O', 'U'};
+
+    public int solution(String word) {
+        
+        dfs(new StringBuilder());
+        
+        return list.indexOf(word);
+    }
+
+    static void dfs(StringBuilder sb) {
+        if (sb.length() > 5) return;
+
+        list.add(sb.toString());
+
+        for (int i = 0; i < 5; i++) {
+            sb.append(vowels[i]);
+            dfs(sb);
+            sb.deleteCharAt(sb.length() - 1);
+        }
+    }
+}

--- a/재현/6주차/월/전력망을 둘로 나누기.java
+++ b/재현/6주차/월/전력망을 둘로 나누기.java
@@ -1,0 +1,57 @@
+import java.util.*;
+
+class Solution {
+    static List<Integer>[] list;
+    
+    public int solution(int n, int[][] wires) {
+        
+        int answer = Integer.MAX_VALUE;
+        
+        list = new ArrayList[n + 1];
+        for (int i = 1; i <= n; i++) {
+            list[i] = new ArrayList<>();
+        }
+
+        for (int[] wire : wires) {
+            list[wire[0]].add(wire[1]);
+            list[wire[1]].add(wire[0]);
+        }
+        
+        for (int[] wire : wires) {
+            int src = wire[0];
+            int dst = wire[1];
+
+            list[src].remove(Integer.valueOf(dst));
+            list[dst].remove(Integer.valueOf(src));
+
+            int rs = Math.abs(n - 2 * bfs(src, n));
+            answer = Math.min(answer, rs);
+
+            list[src].add(dst);
+            list[dst].add(src);
+        }
+        
+        return answer;
+    }
+    
+    static int bfs(int start, int n) {
+        boolean[] visited = new boolean[n + 1];
+        Queue<Integer> q = new LinkedList<>();
+        q.add(start);
+        visited[start] = true;
+        int count = 1;
+
+        while (!q.isEmpty()) {
+            int now = q.poll();
+            for (int next : list[now]) {
+                if (!visited[next]) {
+                    visited[next] = true;
+                    q.add(next);
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
1. 모음사전
- DFS를 이용하여 모음을 이용하여 만들 수 있는 모든 문자열을 구하여 list에 추가
- list에서 구해야하는 문자열의 인덱스를 찾아서 출력
- StringBuilder를 이용하여 문자열을 더할때 연산 메모리 최적화

2. 전력망을 둘로 나누기
- List 배열을 이용하여 wire의 정보를 정리
- 전체 간선들 중 하나씩 지우면서 BFS를 진행하여 차가 가장 적은 결과를 업데이트
- BFS를 이용하여 전력망 안의 개수를 구함

---
### 알게된 점
- list에서 remove를 할때 매개변수에 따라 인덱스에 있는 값을 지울지 아니면 값에 해당하는 부분을 지울지에 대해 결정할 수 있다.
- `list[src].remove(Integer.valueOf(dst));` 라고 작성하는 경우 list[src]에서 dst라는 값을 삭제하라는 뜻이고
- `list[src].remove(dst);` 라고 작성하는 경우는 list[src]에서 dst 인덱스를 삭제하라는 의미로 
- remove 메서드는 오버로딩되어 있어 int를 넣으면 인덱스를 삭제하고, Object 객체를 넣으면 해당 값을 삭제한다.
