### PR TITLE
[6주차] 한지은 - 월 모음사전, 전력망을 둘로 나누기

### DIFF
--- a/지은/6주차/월/모음사전.java
+++ b/지은/6주차/월/모음사전.java
@@ -1,0 +1,27 @@
+import java.util.*;
+
+class Solution {
+    List<String> list = new ArrayList<>();
+    char[] ch = {'A', 'E', 'I', 'O', 'U'};
+
+    public int solution(String word) {
+        DFS("", 0);
+        return list.indexOf(word) + 1;
+    }
+
+    // current : 현재까지 만든 단어
+    // depth : 현재 단어까지의 길이 (최대 5개)
+    void DFS(String current, int depth) {
+        if (depth > 5) return;
+
+        // 빈 문자열 제외
+        if (!current.equals("")) {
+            list.add(current);
+        }
+
+        // 재귀 호출
+        for (char c : ch) {
+            DFS(current + c, depth + 1);
+        }
+    }
+}

--- a/지은/6주차/월/전력망을 둘로 나누기.java
+++ b/지은/6주차/월/전력망을 둘로 나누기.java
@@ -1,0 +1,62 @@
+import java.util.*;
+
+class Solution {
+    List<Integer>[] graph;
+    boolean[] visited; // 방문 여부
+    int count; // 방문 노드 수
+
+    public int solution(int n, int[][] wires) {
+        int answer = Integer.MAX_VALUE;
+
+        // 그래프 초기화 (1번 노드부터 시작, n+1)
+        graph = new ArrayList[n + 1];
+        for (int i = 1; i <= n; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        // 간선 정보 저장
+        for (int[] wire : wires) {
+            int a = wire[0];
+            int b = wire[1];
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+
+        // 간선 하나씩 끊어서 두 전력망으로 나눠보기
+        for (int[] wire : wires) {
+            int a = wire[0];
+            int b = wire[1];
+
+            // 간선 끊기 (양방향이므로 양쪽 제거)
+            graph[a].remove(Integer.valueOf(b));
+            graph[b].remove(Integer.valueOf(a));
+
+            // 끊어진 상태에서 한 쪽에 DFS 수행
+            visited = new boolean[n + 1];
+            count = 0;
+            DFS(a); // 한 쪽 송전탑 개수가 count에 누적
+
+            // 두 전력망의 송전탑 개수 차이 계산
+            int diff = (count > n - count) ? count - (n - count) : (n - count) - count;
+            answer = Math.min(answer, diff);
+
+            // 끊은 간선 복원
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+
+        return answer;
+    }
+
+    // DFS로 연결된 송전탑 개수 누적
+    void DFS(int node) {
+        visited[node] = true;
+        count++;
+
+        for (int next : graph[node]) {
+            if (!visited[next]) {
+                DFS(next);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 모음사전

- DFS 사용하여 AEIOU로 만들 수 있는 길이 1~5의 모든 문자열 조합 생성
- 빈 문자열은 리스트에 포함되지 않도록 조건 처리
- 리스트에 저장된 문자를 indexOf로 위치 반환
- 가중치 계산 없이 완전탐색 기반으로 구현
---
## 전력망을 둘로 나누기

- 각 간선을 하나씩 끊고, 두 전력망으로 나뉜 상태를 완전탐색
- 인접 리스트로 그래프 구성하고, DFS로 한 쪽 송전탑 개수(count)를 누적
- 간선 제거 후 복구를 반복하여 송전탑 개수 차이의 최소 차이값을 갱신
