### PR TITLE
[6주차] 김하나 - 월 모음사전, 전력망을 둘로 나누기

### DIFF
--- a/하나/6주차/월/모음사전.java
+++ b/하나/6주차/월/모음사전.java
@@ -1,0 +1,22 @@
+class 모음사전 {
+    public int solution(String word) {
+        int answer = 0;
+        char[] vowels = {'A', 'E', 'I', 'O', 'U'};
+        int[] weights = {781, 156, 31, 6, 1}; // 자리별 가중치
+
+        for (int i = 0; i < word.length(); i++) {
+            char c = word.charAt(i);
+
+            // 현재 글자가 vowels 배열에서 몇 번째인지 찾기
+            for (int j = 0; j < vowels.length; j++) {
+                if (vowels[j] == c) {
+                    answer += j * weights[i]; // 앞선 조합 수 모두 더함
+                    break;
+                }
+            }
+        }
+
+        // 자기 자신도 포함해야 하므로 +
+        return answer + word.length();
+    }
+}

--- a/하나/6주차/월/전력망을둘로나누기.java
+++ b/하나/6주차/월/전력망을둘로나누기.java
@@ -1,0 +1,53 @@
+import java.util.*;
+
+class 전력망을둘로나누기 {
+    public int solution(int n, int[][] wires) {
+        int answer = n;
+        
+        for(int i = 0; i<wires.length; i++){
+            //그래프 초기화
+            List<List<Integer>> graph = new ArrayList<>();
+            for(int j = 0; j <= n; j++){
+                graph.add(new ArrayList<>());
+            }
+            
+            //i번째 전선을 제거한 그래프 구성
+            for(int j = 0; j < wires.length; j++){
+                if(i==j) continue; //전선을 끊음
+                int a = wires[j][0];
+                int b = wires[j][1];
+                graph.get(a).add(b);
+                graph.get(b).add(a);
+            }
+            //한 쪽 트리의 노드 개수 계산
+            int count = bfs(1, graph, n);
+            //두 트리의 차이 계산
+            int diff = Math.abs(n-count-count);
+            answer = Math.min(answer, diff);
+        }
+        return answer;
+    }
+    
+    private int bfs(int start, List<List<Integer>> graph, int n){
+        boolean[] visited = new boolean[n+1];
+        Queue<Integer> queue = new LinkedList<>();
+        queue.add(start);
+        visited[start] = true;
+        
+        int count = 1;
+        
+        //현재 노드 이웃 노드를 방문하며 큐에 추가
+        while(!queue.isEmpty()){
+            int node = queue.poll();
+            for(int next : graph.get(node)){
+                if(!visited[next]){
+                    visited[next] = true;
+                    queue.offer(next);
+                    count++;
+                }
+            }
+        }
+        //트리의 한 쪽 노드 수 반환
+        return count;
+    }
+}


### PR DESCRIPTION
## 문제풀이

1. 모음 사전
- 각 자리마다 가중치를 두고 문자에 해당하는 단어 이전까지 만들어진 모든 조합 수를 계산  
- 마지막에 해당 단어 자체를 포함시키기 위해 단어의 길이만큼 더해 최종 순서를 구현
- 모음이 5개로 제한되고 사전 순서를 계산하는 구조가 5진법처럼 느껴져 응용해봤습니다!
--- 
2. 전력망을 둘로 나누기
- 모든 간선을 하나씩 제거하면서 그래프를 구성
- BFS로 한 쪽 트리의 노드 수를 계산
- 전체 노드 수에서 반대편 트리 노드 수를 구한 뒤 두 트리의 노드 수 차이의 최솟값을 구함