### PR TITLE
[8주차] 장혁 - 수 입국심사

### DIFF
--- a/혁/8주차/수/입국심사.java
+++ b/혁/8주차/수/입국심사.java
@@ -1,0 +1,39 @@
+package 수;
+
+// n = 6  times = [7, 10] return 28
+
+public class 입국심사 {
+
+    public long countPerson(int[] times, long t) {
+        long total = 0;
+        for (int time : times) {
+            total += t / time;
+        }
+        return total;
+    }
+
+    int getMax(int []arr){
+        int max = arr[0];
+        for (int a : arr) {
+            max = Math.max(max, a);
+        }
+        return max;
+    }
+
+    public long solution(int n, int[] times) {
+        long min = 1;
+        long max = (long) getMax(times) * n;
+        long answer = max;
+        while (min <= max) {
+            long center = (min + max) / 2;
+            long processed = countPerson(times, center);
+            if (processed >= n) {
+                answer = center;
+                max = center - 1;
+            }else{
+                min = center + 1;
+            }
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
# 🛂 입국심사 문제

## 📌 풀이 전략

### ✅ 1. 가능한 시간 범위 설정
- **최소 시간**: `1`
- **최대 시간**: 가장 느린 심사관이 `n`명을 전부 처리하는 경우  

### ✅ 2. 이진 탐색으로 최소 시간 탐색
- `mid` 시간에 심사 가능한 사람 수를 계산
- 그 수가 `n`명 이상이면  
  → 시간 줄이기 (`max = center - 1`)
- 부족하면  
  → 시간 늘리기 (`min = center + 1`)
- 가능한 시간 중 최솟값을 `answer`에 저장

### ✅ 3. 시간 동안 처리 가능한 사람 수 계산
- `center` 시간 동안 각 심사관이 처리 가능한 인원  
  → `center / time`
- 모든 심사관의 처리 인원을 합산

### ✅ 4. 결과값 반환
- 모든 사람이 심사를 받는 데 필요한 **최소 시간**  
  → `answer`를 반환
