### PR TITLE
[8주차] 정경조 - 수 입국심사

### DIFF
--- a/경조/8주차/수/입국심사.java
+++ b/경조/8주차/수/입국심사.java
@@ -1,0 +1,32 @@
+import java.util.*;
+public class 입국심사 {
+    public long solution(int n, int[] times) {
+        Arrays.sort(times);
+        long answer = 0;
+
+        long start = 0;
+        // 최대로 걸리는 시간
+        long end = (long) times[times.length-1] * n;
+
+        while(start <= end) {
+            long mid = (start + end) / 2;
+            long sum = 0;
+
+            // 해당 시간(mid 값) 동안 심사한 인원 sum에 저장
+            for(int time : times) {
+                sum += mid / time;
+            }
+
+            // 만약 심사를 다한 경우
+            if(sum >= n) {
+                answer = mid;
+                end = mid - 1;
+            }
+            // 심사를 다 못 한 경우
+            else start = mid + 1;
+
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제풀이
### 입국심사
- 처음에 이걸 시간복잡도를 따지면 완전탐색으로는 절대 못 푸는 문제여서 이진탐색(이분탐색)으로 어떻게 풀어야 하나 싶었습니다.
- 최저 시간(0) ~ 최대 시간(제일 느린 탐색대 * 인원수)을 이분 탐색하는 문제입니다.
- 만약 `mid`로 구한 시간을 각각의 탐색대에서 걸리는 시간으로 나눠 `sum` 값에 저장합니다.
- `sum` 값이 주어진 `n`보다 크거나 같으면 더 작은 시간으로도 완료할 수 있는지 반복합니다.