### PR TITLE
[10주차] 김재현 - 월 멀리 뛰기

### DIFF
--- a/재현/10주차/월/멀리 뛰기.java
+++ b/재현/10주차/월/멀리 뛰기.java
@@ -1,0 +1,14 @@
+class Solution {
+    public long solution(int n) {
+        long[] dp = new long[2001];
+        
+        dp[1] = 1;
+        dp[2] = 2;
+        
+        for (int i = 3; i <= n; i++) {
+            dp[i] = (dp[i - 1] + dp[i - 2]) % 1234567;
+        }
+        
+        return dp[n];
+    }
+}


### PR DESCRIPTION
1. 멀리 뛰기
- 가능한 횟수를 저장해주기 위한 dp 배열 생성
- 1칸과 2칸의 경우에는 규칙이 없기 때문에 1과 2를 대입
- 3칸 이상부터는 전 칸 + 전전 칸의 합의 횟수만큼 경우의 수가 생김 
- `n 번칸을 가야할 경우 n-1번칸에서 1칸 이동, n-2번칸에서 2칸 이동`
- 계속 더해주면 오버플로우가 발생하므로 횟수를 구할때 마다 1234567로 나눈 나머지를 저장
- `dp[i] = (dp[i - 1] + dp[i -2]) % 1234567`
- n까지 반복하며 dp[n]을 반환