### PR TITLE
[10주차] 정경조 - 월 멀리 뛰기

### DIFF
--- a/경조/10주차/월/멀리뛰기.java
+++ b/경조/10주차/월/멀리뛰기.java
@@ -1,0 +1,16 @@
+public class 멀리뛰기 {
+    public long solution(int n) {
+        if (n == 1) return 1;
+        if (n == 2) return 2;
+
+        long[] answer = new long[n + 1];
+        answer[1] = 1;
+        answer[2] = 2;
+
+        for (int i = 3; i <= n; i++) {
+            answer[i] = (answer[i - 1] + answer[i - 2]) % 1234567;
+        }
+
+        return answer[n];
+    }
+}


### PR DESCRIPTION
## 문제 풀이
### 멀리 뛰기
- 초반에 피보나치 수열을 생각하고 재귀로 구현했다가 시간초과가 났습니다.
- answer 배열 크기를 `n+1`로 구현한 이유는 n이 3이면 answer[3]에 저장을 해주기 위해서입니다.
- 기하급수적으로 늘어나기 때문에 계속 더하게 된다면 오버플로우가 날 수 있습니다. 
- 따라서 `%1234567`를 해주면서 answer에 저장해줘야 합니다.