### PR TITLE
[11주차] 조아빈 - 월 등굣길

### DIFF
--- a/아빈/11주차/월/등굣길.java
+++ b/아빈/11주차/월/등굣길.java
@@ -1,0 +1,23 @@
+class 등굣길 {
+	public int solution(int m, int n, int[][] puddles) {
+		int[][] map = new int[n][m];
+
+		for(int[] arr : puddles){
+			map[arr[1] - 1][arr[0] - 1] = -1;
+		}
+
+		map[0][0] = 1;
+
+		for(int i = 0; i < n; i++) {
+			for(int j = 0; j < m; j++){
+				if(map[i][j] == -1) {
+					map[i][j] = 0;
+					continue;
+				}
+				if(i > 0) map[i][j] = (map[i][j] + map[i-1][j]) % 1000000007;
+				if(j > 0) map[i][j] = (map[i][j] + map[i][j-1]) % 1000000007;
+			}
+		}
+		return map[n - 1][m - 1];
+	}
+}


### PR DESCRIPTION
### 문제 풀이
- 등굣길
  - 해당 문제는 주어진 물웅덩이의 위치를 피해서 목적지까지 오른쪽과 아래로만 이동하여 갈 수 있는 최단거리 개수를 구하는 문제였습니다.
  - 물 웅덩이의 위치를 -1로 초기화 하여 계산에서 제외할 수 있도록 하였습니다.
  - dp[i][j] = dp[i - 1][j] + dp[i][j - 1] 의 점화식을 활용하여 나머지 연산 후 map 배열에 누적시켜 마지막 목적지의 값을 반환하였습니다.