### PR TITLE
[13주차] 정경조 - 월 숫자 게임, 방문 길이

### DIFF
--- a/경조/13주차/월/방문길이.java
+++ b/경조/13주차/월/방문길이.java
@@ -1,0 +1,42 @@
+public class 방문길이 {
+    public int solution(String dirs) {
+        int answer = 0;
+        int[] dx = {1, -1, 0, 0};
+        int[] dy = {0, 0, 1, -1};
+        // 좌우상하 -> 0, 1, 2, 3
+        boolean[][][] visited = new boolean[11][11][4];
+
+        int x = 5;
+        int y = 5;
+        int d = -1;
+        for(char dir : dirs.toCharArray()) {
+            // 좌우상하 순서
+            if(dir == 'L') d = 0;
+            if(dir == 'R') d = 1;
+            if(dir == 'U') d = 2;
+            if(dir == 'D') d = 3;
+
+            int nx = x + dx[d];
+            int ny = y + dy[d];
+
+            if(check(nx, ny)) {
+                if(!visited[nx][ny][d]) {
+                    // 반대방향
+                    int opposite = (d % 2) == 0 ? d + 1 : d - 1;
+                    // 방문한 곳 <-> 왔던 곳 양방향으로 방문 추가
+                    visited[x][y][opposite] = true;
+                    visited[nx][ny][d] = true;
+                    answer++;
+                }
+                x = nx;
+                y = ny;
+            }
+        }
+
+        return answer;
+    }
+
+    private boolean check(int x, int y) {
+        return (x >= 0) && (x < 11) && (y >= 0) && (y < 11);
+    }
+}

--- a/경조/13주차/월/숫자게임.java
+++ b/경조/13주차/월/숫자게임.java
@@ -1,0 +1,21 @@
+import java.util.*;
+public class 숫자게임 {
+    public int solution(int[] A, int[] B) {
+        int answer = 0;
+        Arrays.sort(A);
+        Arrays.sort(B);
+
+        int idxA = 0;
+        int idxB = 0;
+
+        for(int i = 0; i < A.length; i++) {
+            if(A[idxA] < B[idxB]) {
+                idxA++;
+                idxB++;
+                answer++;
+            } else idxB++;
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제 풀이
### 숫자 게임
- `그리디 알고리즘`을 적용하여 풀었습니다.
- `A`, `B`를 정렬해주었습니다.
- `idxA`, `idxB`를 정의하였습니다.
  - `A[idxA]` < `B[idxB]`라면 `idxA`, `idxB`, `answer`를 모두 증가
  - 아니라면 `idxB`만 증가해서 다시 비교합니다.
---
### 방문 길이
- 좌표평면 문제라 초반에 visited를 방문하는 방향까지 체크하기 위해 3차원 배열로 선언하긴 했지만 `[10][10][4]`로 선언했습니다.
- 하지만 좌표평면 상으로 -5 ~ 5까지는 총 11개의 숫자가 있기 때문에 `[11][11][4]`로 선언해줘야 합니다.
- `check` 함수: 다음 방문할 좌표`(nx, ny)`가 유효한지
- `d`: 방향`(좌: 0, 우: 1, 상: 2, 하: 3)`
- 현재 방향`(d)`으로 방문할 좌표`(nx, ny)`를 방문하지 않았다면 `visited[nx][ny][d]` 방문 처리
- `opposite`: `d`와 반대 방향 -> `(d % 2) == 0 ? d + 1 : d - 1`
- 방문할 좌표`(nx, ny)`에서 기존 방향`(x, y)` 방향으로도 `vistied[x][y][opposite]` 방문 처리