### PR TITLE
[13주차] 이유민 - 월 숫자 게임, 방문 길이

### DIFF
--- a/유민/13주차/월/방문길이.java
+++ b/유민/13주차/월/방문길이.java
@@ -1,0 +1,40 @@
+import java.util.*;
+
+public class 방문길이 {
+    public int solution(String dirs) {
+        int r = 0, c = 0;
+        Set<String> visited = new HashSet<>();
+
+        for(char dir : dirs.toCharArray()) {
+            int nr = r, nc = c;
+
+            if(dir == 'U') {
+                nr++;
+            } else if(dir == 'D') {
+                nr--;
+            } else if(dir == 'R') {
+                nc++;
+            } else {
+                nc--;
+            }
+
+            if(!isValid(nr, nc))
+                continue;
+
+            String path = r + "," + c + "->" + nr + "," + nc;
+            String reverse = nr + "," + nc + "->" + r + "," + c;
+
+            visited.add(path);
+            visited.add(reverse);
+
+            r = nr;
+            c = nc;
+        }
+
+        return visited.size() / 2;
+    }
+
+    boolean isValid(int r, int c) {
+        return (r <= 5 && r >= -5) && (c <= 5 && c >= -5);
+    }
+}

--- a/유민/13주차/월/숫자게임.java
+++ b/유민/13주차/월/숫자게임.java
@@ -1,0 +1,23 @@
+import java.util.*;
+
+public class 숫자게임 {
+    public int solution(int[] A, int[] B) {
+        int length = A.length;
+        int answer = 0;
+        int a = 0, b = 0;
+
+        // 정렬 먼저
+        Arrays.sort(A);
+        Arrays.sort(B);
+
+        while(a < length && b < length) {
+            if(B[b] > A[a]) {
+                answer++;
+                a++;
+            }
+            b++;
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 숫자게임

- A와 B 배열을 오름차순 정렬하여, B가 A보다 큰 값을 매칭할 수 있도록 구성
- 두 인덱스를 비교해 A의 각 원소보다 큰 B의 원소가 나오면 카운트 증가

## 방문길이

- 좌표 이동 명령(dirs)에 따라 U/D/R/L 방향으로 이동하면서 방문 경로를 기록
- 경로는 방향성을 제거하기 위해 path와 reverse를 모두 저장하고, 최종적으로 절반 개수를 반환